### PR TITLE
Update XSendFilePath when MEDIA_PATH is set

### DIFF
--- a/koel-entrypoint
+++ b/koel-entrypoint
@@ -5,6 +5,12 @@ set -e
 # Change to program root directory.
 cd /var/www/html
 
+# Set X-SendFile path
+if [[ "$MEDIA_PATH" != "/music" ]]; then
+    echo "Updating XSendFilePath to $MEDIA_PATH"
+    sed --regexp-extended --in-place "s|XSendFilePath.+$|XSendFilePath $MEDIA_PATH|" /etc/apache2/sites-available/000-default.conf
+fi
+
 # Run the next entrypoint in the chain.
 echo "running docker-php-entrypoint with arguments $@"
 docker-php-entrypoint $@


### PR DESCRIPTION
Currently the XSendFilePath is hard-coded in `apache.conf`. When I migrated a previous install to a docker host I kept the original directory path instead of using the default `/music` and this was required in order to get files to play while still using x-sendfile as the streaming method.