### PR TITLE
Set postgres docker-compose port to 5432 (default)

### DIFF
--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - DB_CONNECTION=pgsql
       - DB_HOST=database
+      - DB_PORT=5432
       - DB_USERNAME=koel
       - DB_PASSWORD=<koel_password>
       - DB_DATABASE=koel


### PR DESCRIPTION
I had trouble getting the postgres docker-compose to work. Turns out it was because the port was defaulting incorrectly (probably defaults to mysql 3306?).

Setting the port explicitly fixes the issue.