### PR TITLE
Add start params to docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,5 +105,5 @@ CMD ["apache2-foreground"]
 EXPOSE 80
 
 # Check that the homepage is displayed
-HEALTHCHECK --interval=5m --timeout=5s \
+HEALTHCHECK --start-period=30s --start-interval=5s --interval=5m --timeout=5s \
   CMD curl -f http://localhost/sw.js || exit 1


### PR DESCRIPTION
Currently the healthcheck is defined with only an interval. Due to the default start period being 0s in docker, it doesn't do an actual healthcheck until the container has been up for 5 minutes.

If a reverse proxy relies on this healthcheck (like when running koel behind traefik), this means not reported as healthy until the container has existed for 5 minutes
![image](https://github.com/user-attachments/assets/25207a0e-abc1-4e02-a48f-0a62441d227e)

By defining a start period of 30s with a start interval of 5 seconds, it will be checked every 5 seconds during the initial 30s lifespan, any failures during this timespam will be ignored as the container still starting up.