### PR TITLE
fix: let Koel serve the PWA manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Since this docker image only has one tag which is `latest`, there are no versions. However we'll write changes with the date at which they occured.
 
+## 2026-09-09
+### Fixed
+- Koel now creates the manifest (the file that lets you install Koel as an app) at `/manifest.json`. The `start_url` value comes from `APP_URL`. The name comes from your custom name on Koel Plus. Before this change, the file held the placeholder address `https://your.koel.host`. You do not have to edit or bind-mount the file. To keep a manifest that you wrote, bind-mount it over `/var/www/html/public/manifest.json`, and Koel serves your file instead.
+
 ## 2026-05-22
 ### Fixed
 - ⚠ Image storage path moved to follow koel/koel#2479. If you're upgrading from a previous release, update your `docker-compose.yml` so the `image_storage` volume binds to `/var/www/html/storage/app/public/images` instead of `/var/www/html/public/img/storage`. Existing data in your `image_storage` volume / host bind transfers over automatically when you switch the mount point — files inside the volume don't move, only the mount path inside the container does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Since this docker image only has one tag which is `latest`, there are no version
 
 ## 2026-09-09
 ### Fixed
-- Koel now creates the manifest (the file that lets you install Koel as an app) at `/manifest.json`. The `start_url` value comes from `APP_URL`. The name comes from your custom name on Koel Plus. Before this change, the file held the placeholder address `https://your.koel.host`. You do not have to edit or bind-mount the file. To keep a manifest that you wrote, bind-mount it over `/var/www/html/public/manifest.json`, and Koel serves your file instead.
+- Koel now creates the manifests (the files that let you install Koel as an app) at `/manifest.json` and `/manifest-remote.json`. The `start_url` value comes from `APP_URL`. The name comes from your custom name on Koel Plus. Before this change, the files held a placeholder address `https://your.koel.host`. You do not have to edit or bind-mount the file. To keep a manifest that you wrote, bind-mount it over `/var/www/html/public/manifest.json`, and Koel serves your file instead.
 
 ## 2026-05-22
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,6 @@ RUN a2enmod rewrite
 
 # Copy the downloaded release
 RUN cp -R /tmp/koel/. /var/www/html \
-  && mv /var/www/html/public/manifest.json.example /var/www/html/public/manifest.json \
   # The release tarball ships public/storage as an absolute symlink into the path the
   # release runner built it at, which resolves nowhere here and leaves koel unable to read
   # or write uploaded images. Replace it with a relative link to the same target.

--- a/goss.yaml
+++ b/goss.yaml
@@ -15,11 +15,6 @@ file:
     owner: www-data
     group: www-data
     filetype: directory
-  /var/www/html/public/manifest.json:
-    exists: true
-    owner: www-data
-    group: www-data
-    filetype: file
   /var/www/html/.git:
     exists: false
   /var/www/html/.github:


### PR DESCRIPTION
Companion to koel/koel#2662, which fixes koel/koel#2659.

## Why

`Dockerfile` moved `public/manifest.json.example` into place at build time:

```dockerfile
&& mv /var/www/html/public/manifest.json.example /var/www/html/public/manifest.json \
```

`koel:init` runs at container start with the mounted `.env` available, but by then the file already exists, so it printed *"manifest.json already exists -- skipping"* and the placeholder `start_url` of `https://your.koel.host` survived. Users had to bind-mount a corrected manifest, since `public/` is not a volume and an in-container edit does not survive `docker compose pull && up -d`.

## What changes

Koel now serves `/manifest.json` and `/manifest-remote.json` itself, built from `APP_URL` and the branded name, so the image does not need to place a file at all.

This is not optional once koel/koel#2662 lands: the release tarball stops shipping the `.example` files, and `mv` on a missing file fails and takes the whole `RUN` chain with it. **It needs to merge before the next image build.**

The `goss.yaml` assertion that `public/manifest.json` exists goes with it, since nothing creates that file any more.

Bind-mounting your own manifest still works and still wins — the web server serves a real file ahead of PHP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamically generated web app manifests at `/manifest.json` and `/manifest-remote.json`.
  - Manifest start URLs now use the configured `APP_URL`, and the Koel Plus custom name is included.
  - Custom manifests can be preserved by bind-mounting them over the public manifest path.

- **Documentation**
  - Added changelog documentation covering dynamic manifest generation and custom manifest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->